### PR TITLE
32-implement-BeanDefinitionRegistry-interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     // JUnit Jupiter
     testImplementation platform("org.junit:junit-bom:${versions.junit}")
     testImplementation "org.junit.jupiter:junit-jupiter"
+    testImplementation "org.mockito:mockito-core:${versions.mockito}"
 }
 
 checkstyle {

--- a/src/main/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImpl.java
+++ b/src/main/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImpl.java
@@ -14,7 +14,7 @@ public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
     public final void registerBeanDefinition(String beanName, BeanDefinition beanDefinition) {
         if (beanDefinitionMap.containsKey(beanName)) {
             throw new BeanDefinitionStoreException(String.format("Cannot register bean definition with name '%s' " +
-                    "another bean with the same name already exists and overriding is not allowed.", beanName));
+                                                                 "another bean with the same name already exists and overriding is not allowed.", beanName));
         }
         beanDefinitionMap.put(beanName, beanDefinition);
     }
@@ -22,7 +22,7 @@ public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
     @Override
     public final void removeBeanDefinition(String beanName) {
         if (!beanDefinitionMap.containsKey(beanName)) {
-            throw new BeanDefinitionStoreException( String.format("No bean definition found for name '%s'", beanName));
+            throw new BeanDefinitionStoreException(String.format("No bean definition found for name '%s'", beanName));
         }
         beanDefinitionMap.remove(beanName);
     }
@@ -46,6 +46,4 @@ public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
     public final int getBeanDefinitionCount() {
         return beanDefinitionMap.size();
     }
-
 }
-

--- a/src/main/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImpl.java
+++ b/src/main/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImpl.java
@@ -13,8 +13,8 @@ public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
     @Override
     public void registerBeanDefinition(String beanName, BeanDefinition beanDefinition) {
         if (beanDefinitionMap.containsKey(beanName)) {
-            throw new BeanDefinitionStoreException("Cannot register bean definition with name '" + beanName +
-                    "': another bean with the same name already exists and overriding is not allowed.");
+            throw new BeanDefinitionStoreException(String.format("Cannot register bean definition with name '%s' " +
+                    "another bean with the same name already exists and overriding is not allowed.", beanName));
         }
         beanDefinitionMap.put(beanName, beanDefinition);
     }
@@ -22,7 +22,7 @@ public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
     @Override
     public void removeBeanDefinition(String beanName) {
         if (!beanDefinitionMap.containsKey(beanName)) {
-            throw new BeanDefinitionStoreException("No bean definition found for name '" + beanName + "'");
+            throw new BeanDefinitionStoreException( String.format("No bean definition found for name '%s'", beanName));
         }
         beanDefinitionMap.remove(beanName);
     }

--- a/src/main/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImpl.java
+++ b/src/main/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImpl.java
@@ -1,0 +1,49 @@
+package com.codeus.winter.config.impl;
+
+import com.codeus.winter.config.BeanDefinition;
+import com.codeus.winter.config.BeanDefinitionRegistry;
+import com.codeus.winter.exception.BeanDefinitionStoreException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
+    private final Map<String, BeanDefinition> beanDefinitionMap = new HashMap<>();
+
+    @Override
+    public void registerBeanDefinition(String beanName, BeanDefinition beanDefinition) {
+        if (beanDefinitionMap.containsKey(beanName)) {
+            throw new BeanDefinitionStoreException("Cannot register bean definition with name '" + beanName +
+                    "': another bean with the same name already exists and overriding is not allowed.");
+        }
+        beanDefinitionMap.put(beanName, beanDefinition);
+    }
+
+    @Override
+    public void removeBeanDefinition(String beanName) {
+        if (!beanDefinitionMap.containsKey(beanName)) {
+            throw new BeanDefinitionStoreException("No bean definition found for name '" + beanName + "'");
+        }
+        beanDefinitionMap.remove(beanName);
+    }
+
+    @Override
+    public BeanDefinition getBeanDefinition(String beanName) {
+        return beanDefinitionMap.get(beanName);
+    }
+
+    @Override
+    public boolean containsBeanDefinition(String beanName) {
+        return beanDefinitionMap.containsKey(beanName);
+    }
+
+    @Override
+    public String[] getBeanDefinitionNames() {
+        return beanDefinitionMap.keySet().toArray(new String[0]);
+    }
+
+    @Override
+    public int getBeanDefinitionCount() {
+        return beanDefinitionMap.size();
+    }
+}

--- a/src/main/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImpl.java
+++ b/src/main/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImpl.java
@@ -14,7 +14,7 @@ public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
     public final void registerBeanDefinition(String beanName, BeanDefinition beanDefinition) {
         if (beanDefinitionMap.containsKey(beanName)) {
             throw new BeanDefinitionStoreException(String.format("Cannot register bean definition with name '%s' " +
-                                                                 "another bean with the same name already exists and overriding is not allowed.", beanName));
+                 "another bean with the same name already exists and overriding is not allowed.", beanName));
         }
         beanDefinitionMap.put(beanName, beanDefinition);
     }
@@ -46,4 +46,5 @@ public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
     public final int getBeanDefinitionCount() {
         return beanDefinitionMap.size();
     }
+
 }

--- a/src/main/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImpl.java
+++ b/src/main/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImpl.java
@@ -11,7 +11,7 @@ public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
     private final Map<String, BeanDefinition> beanDefinitionMap = new HashMap<>();
 
     @Override
-    public void registerBeanDefinition(String beanName, BeanDefinition beanDefinition) {
+    public final void registerBeanDefinition(String beanName, BeanDefinition beanDefinition) {
         if (beanDefinitionMap.containsKey(beanName)) {
             throw new BeanDefinitionStoreException(String.format("Cannot register bean definition with name '%s' " +
                     "another bean with the same name already exists and overriding is not allowed.", beanName));
@@ -20,7 +20,7 @@ public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
     }
 
     @Override
-    public void removeBeanDefinition(String beanName) {
+    public final void removeBeanDefinition(String beanName) {
         if (!beanDefinitionMap.containsKey(beanName)) {
             throw new BeanDefinitionStoreException( String.format("No bean definition found for name '%s'", beanName));
         }
@@ -28,22 +28,24 @@ public class BeanDefinitionRegistryImpl implements BeanDefinitionRegistry {
     }
 
     @Override
-    public BeanDefinition getBeanDefinition(String beanName) {
+    public final BeanDefinition getBeanDefinition(String beanName) {
         return beanDefinitionMap.get(beanName);
     }
 
     @Override
-    public boolean containsBeanDefinition(String beanName) {
+    public final boolean containsBeanDefinition(String beanName) {
         return beanDefinitionMap.containsKey(beanName);
     }
 
     @Override
-    public String[] getBeanDefinitionNames() {
+    public final String[] getBeanDefinitionNames() {
         return beanDefinitionMap.keySet().toArray(new String[0]);
     }
 
     @Override
-    public int getBeanDefinitionCount() {
+    public final int getBeanDefinitionCount() {
         return beanDefinitionMap.size();
     }
+
 }
+

--- a/src/main/java/com/codeus/winter/context/AnnotationApplicationContext.java
+++ b/src/main/java/com/codeus/winter/context/AnnotationApplicationContext.java
@@ -1,10 +1,12 @@
 package com.codeus.winter.context;
 
 import com.codeus.winter.config.BeanDefinition;
+import com.codeus.winter.config.BeanDefinitionRegistry;
 import com.codeus.winter.config.BeanFactory;
 import com.codeus.winter.config.BeanPostProcessor;
 import com.codeus.winter.config.ClassPathBeanDefinitionScanner;
 import com.codeus.winter.config.DefaultBeanFactory;
+import com.codeus.winter.config.impl.BeanDefinitionRegistryImpl;
 import com.codeus.winter.exception.BeanNotFoundException;
 import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.ObjectUtils;
@@ -24,6 +26,7 @@ public class AnnotationApplicationContext implements ApplicationContext, BeanFac
     private String displayName = ObjectUtils.identityToString(this);
     private final ClassPathBeanDefinitionScanner scanner;
     private final DefaultBeanFactory beanFactory;
+    private final BeanDefinitionRegistry beanDefinitionRegistry;
 
     /**
      * Constructs a new {@code AnnotationApplicationContext} for the specified base packages.
@@ -31,8 +34,9 @@ public class AnnotationApplicationContext implements ApplicationContext, BeanFac
      * @param basePackages the base packages to scan for component classes
      */
     public AnnotationApplicationContext(String... basePackages) {
+        this.beanDefinitionRegistry = new BeanDefinitionRegistryImpl();
         beanFactory = new DefaultBeanFactory();
-        this.scanner = new ClassPathBeanDefinitionScanner(beanFactory);
+        this.scanner = new ClassPathBeanDefinitionScanner(beanDefinitionRegistry);
         scanner.scanPackages(basePackages);
     }
 

--- a/src/main/java/com/codeus/winter/exception/BeanDefinitionStoreException.java
+++ b/src/main/java/com/codeus/winter/exception/BeanDefinitionStoreException.java
@@ -1,0 +1,24 @@
+package com.codeus.winter.exception;
+
+import javax.annotation.Nullable;
+
+public class BeanDefinitionStoreException extends RuntimeException {
+    /**
+     * Constructor with message.
+     *
+     * @param message message.
+     */
+    public BeanDefinitionStoreException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor with message and cause.
+     *
+     * @param message message.
+     * @param cause   cause.
+     */
+    public BeanDefinitionStoreException(@Nullable final String message, @Nullable final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImplTest.java
+++ b/src/test/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImplTest.java
@@ -1,0 +1,71 @@
+package com.codeus.winter.config.impl;
+
+import com.codeus.winter.config.BeanDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BeanDefinitionRegistryImplTest {
+    private BeanDefinitionRegistryImpl beanFactory;
+
+    @BeforeEach
+    void setUp() {
+        beanFactory = new BeanDefinitionRegistryImpl();
+    }
+
+    @Test
+    @DisplayName("Should create a bean using a mocked BeanDefinition")
+    void testCreateBeanWithMockBeanDefinition() {
+        BeanDefinition mockBeanDefinition = mock(BeanDefinition.class);
+        when(mockBeanDefinition.getBeanClassName()).thenReturn("test.MyTestBean");
+        when(mockBeanDefinition.isSingleton()).thenReturn(true);
+
+        beanFactory.registerBeanDefinition("testBean", mockBeanDefinition);
+
+        Object bean = beanFactory.getBeanDefinition("testBean");
+        assertNotNull(bean, "Bean should not be null");
+    }
+
+    @Test
+    @DisplayName("Should register and retrieve a BeanDefinition successfully")
+    void testRegisterAndRetrieveBeanDefinition() {
+        BeanDefinition mockBeanDefinition = mock(BeanDefinition.class);
+        when(mockBeanDefinition.getBeanClassName()).thenReturn("test.MyTestBean");
+
+        beanFactory.registerBeanDefinition("testBean", mockBeanDefinition);
+
+        BeanDefinition retrievedDefinition = beanFactory.getBeanDefinition("testBean");
+
+        assertNotNull(retrievedDefinition, "BeanDefinition should not be null");
+        assertEquals("test.MyTestBean", retrievedDefinition.getBeanClassName());
+    }
+
+    @Test
+    @DisplayName("Should check if a BeanDefinition exists in the registry")
+    void testContainsBeanDefinition() {
+        BeanDefinition mockBeanDefinition = mock(BeanDefinition.class);
+
+        beanFactory.registerBeanDefinition("testBean", mockBeanDefinition);
+
+        assertTrue(beanFactory.containsBeanDefinition("testBean"), "Registry should contain 'testBean'");
+        assertFalse(beanFactory.containsBeanDefinition("nonExistentBean"), "Registry should not contain 'nonExistentBean'");
+    }
+
+    @Test
+    @DisplayName("Should remove a BeanDefinition from the registry")
+    void testRemoveBeanDefinition() {
+        BeanDefinition mockBeanDefinition = mock(BeanDefinition.class);
+
+        beanFactory.registerBeanDefinition("testBean", mockBeanDefinition);
+        beanFactory.removeBeanDefinition("testBean");
+
+        assertFalse(beanFactory.containsBeanDefinition("testBean"), "Registry should not contain 'testBean' after removal");
+    }
+}

--- a/src/test/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImplTest.java
+++ b/src/test/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImplTest.java
@@ -54,8 +54,10 @@ class BeanDefinitionRegistryImplTest {
 
         beanFactory.registerBeanDefinition("testBean", mockBeanDefinition);
 
-        assertTrue(beanFactory.containsBeanDefinition("testBean"), "Registry should contain 'testBean'");
-        assertFalse(beanFactory.containsBeanDefinition("nonExistentBean"), "Registry should not contain 'nonExistentBean'");
+        assertTrue(beanFactory.containsBeanDefinition("testBean"),
+                "Registry should contain 'testBean'");
+        assertFalse(beanFactory.containsBeanDefinition("nonExistentBean"),
+                "Registry should not contain 'nonExistentBean'");
     }
 
     @Test
@@ -66,6 +68,7 @@ class BeanDefinitionRegistryImplTest {
         beanFactory.registerBeanDefinition("testBean", mockBeanDefinition);
         beanFactory.removeBeanDefinition("testBean");
 
-        assertFalse(beanFactory.containsBeanDefinition("testBean"), "Registry should not contain 'testBean' after removal");
+        assertFalse(beanFactory.containsBeanDefinition("testBean"),
+                "Registry should not contain 'testBean' after removal");
     }
 }

--- a/src/test/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImplTest.java
+++ b/src/test/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImplTest.java
@@ -1,23 +1,36 @@
 package com.codeus.winter.config.impl;
 
 import com.codeus.winter.config.BeanDefinition;
+import com.codeus.winter.exception.BeanDefinitionStoreException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class BeanDefinitionRegistryImplTest {
-    private BeanDefinitionRegistryImpl beanFactory;
+    private BeanDefinitionRegistryImpl registry;
 
     @BeforeEach
     void setUp() {
-        beanFactory = new BeanDefinitionRegistryImpl();
+        registry = new BeanDefinitionRegistryImpl();
+    }
+
+    @Test
+    @DisplayName("Should register a BeanDefinition successfully")
+    void testRegisterBeanDefinition() {
+        BeanDefinition mockBeanDefinition = mock(BeanDefinition.class);
+        registry.registerBeanDefinition("testBean", mockBeanDefinition);
+        assertTrue(registry.containsBeanDefinition("testBean"),
+                "Registry should contain 'testBean'");
     }
 
     @Test
@@ -27,10 +40,21 @@ class BeanDefinitionRegistryImplTest {
         when(mockBeanDefinition.getBeanClassName()).thenReturn("test.MyTestBean");
         when(mockBeanDefinition.isSingleton()).thenReturn(true);
 
-        beanFactory.registerBeanDefinition("testBean", mockBeanDefinition);
+        registry.registerBeanDefinition("testBean", mockBeanDefinition);
 
-        Object bean = beanFactory.getBeanDefinition("testBean");
+        Object bean = registry.getBeanDefinition("testBean");
         assertNotNull(bean, "Bean should not be null");
+    }
+
+    @Test
+    @DisplayName("Should throw exception if a BeanDefinition with the same name already exists")
+    void testRegisterBeanDefinitionThrowsExceptionOnDuplicate() {
+        BeanDefinition mockBeanDefinition = mock(BeanDefinition.class);
+        registry.registerBeanDefinition("testBean", mockBeanDefinition);
+        BeanDefinition anotherMockBeanDefinition = mock(BeanDefinition.class);
+        assertThrows(BeanDefinitionStoreException.class,
+                () -> registry.registerBeanDefinition("testBean", anotherMockBeanDefinition),
+                "Should throw exception if bean name already exists");
     }
 
     @Test
@@ -39,12 +63,20 @@ class BeanDefinitionRegistryImplTest {
         BeanDefinition mockBeanDefinition = mock(BeanDefinition.class);
         when(mockBeanDefinition.getBeanClassName()).thenReturn("test.MyTestBean");
 
-        beanFactory.registerBeanDefinition("testBean", mockBeanDefinition);
+        registry.registerBeanDefinition("testBean", mockBeanDefinition);
 
-        BeanDefinition retrievedDefinition = beanFactory.getBeanDefinition("testBean");
+        BeanDefinition retrievedDefinition = registry.getBeanDefinition("testBean");
 
         assertNotNull(retrievedDefinition, "BeanDefinition should not be null");
         assertEquals("test.MyTestBean", retrievedDefinition.getBeanClassName());
+    }
+
+
+    @Test
+    @DisplayName("Should return null if a BeanDefinition is not found")
+    void testGetBeanDefinitionReturnsNullIfNotFound() {
+        assertNull(registry.getBeanDefinition("nonExistentBean"),
+                "Should return null for non-existent bean");
     }
 
     @Test
@@ -52,24 +84,65 @@ class BeanDefinitionRegistryImplTest {
     void testContainsBeanDefinition() {
         BeanDefinition mockBeanDefinition = mock(BeanDefinition.class);
 
-        beanFactory.registerBeanDefinition("testBean", mockBeanDefinition);
+        registry.registerBeanDefinition("testBean", mockBeanDefinition);
 
-        assertTrue(beanFactory.containsBeanDefinition("testBean"),
+        assertTrue(registry.containsBeanDefinition("testBean"),
                 "Registry should contain 'testBean'");
-        assertFalse(beanFactory.containsBeanDefinition("nonExistentBean"),
+        assertFalse(registry.containsBeanDefinition("nonExistentBean"),
                 "Registry should not contain 'nonExistentBean'");
     }
+
+
 
     @Test
     @DisplayName("Should remove a BeanDefinition from the registry")
     void testRemoveBeanDefinition() {
         BeanDefinition mockBeanDefinition = mock(BeanDefinition.class);
 
-        beanFactory.registerBeanDefinition("testBean", mockBeanDefinition);
-        beanFactory.removeBeanDefinition("testBean");
+        registry.registerBeanDefinition("testBean", mockBeanDefinition);
+        registry.removeBeanDefinition("testBean");
 
-        assertFalse(beanFactory.containsBeanDefinition("testBean"),
+        assertFalse(registry.containsBeanDefinition("testBean"),
                 "Registry should not contain 'testBean' after removal");
+    }
+
+
+    @Test
+    @DisplayName("Should throw exception when removing a non-existent BeanDefinition")
+    void testRemoveBeanDefinitionThrowsExceptionIfNotFound() {
+        assertThrows(BeanDefinitionStoreException.class,
+                () -> registry.removeBeanDefinition("nonExistentBean"),
+                "Should throw exception if trying to remove non-existent bean");
+    }
+
+    @Test
+    @DisplayName("Should retrieve all BeanDefinition names")
+    void testGetBeanDefinitionNames() {
+        BeanDefinition mockBeanDefinition1 = mock(BeanDefinition.class);
+        BeanDefinition mockBeanDefinition2 = mock(BeanDefinition.class);
+
+        registry.registerBeanDefinition("testBean1", mockBeanDefinition1);
+        registry.registerBeanDefinition("testBean2", mockBeanDefinition2);
+
+        String[] beanNames = registry.getBeanDefinitionNames();
+        assertArrayEquals(new String[]{"testBean1", "testBean2"}, beanNames,
+                "Should return all registered bean names");
+    }
+
+    @Test
+    @DisplayName("Should return the correct count of BeanDefinitions")
+    void testGetBeanDefinitionCount() {
+        assertEquals(0, registry.getBeanDefinitionCount(),
+                "Initially, registry should contain 0 BeanDefinitions");
+
+        BeanDefinition mockBeanDefinition1 = mock(BeanDefinition.class);
+        BeanDefinition mockBeanDefinition2 = mock(BeanDefinition.class);
+
+        registry.registerBeanDefinition("testBean1", mockBeanDefinition1);
+        registry.registerBeanDefinition("testBean2", mockBeanDefinition2);
+
+        assertEquals(2, registry.getBeanDefinitionCount(),
+                "Registry should contain 2 BeanDefinitions");
     }
 
 }

--- a/src/test/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImplTest.java
+++ b/src/test/java/com/codeus/winter/config/impl/BeanDefinitionRegistryImplTest.java
@@ -71,4 +71,5 @@ class BeanDefinitionRegistryImplTest {
         assertFalse(beanFactory.containsBeanDefinition("testBean"),
                 "Registry should not contain 'testBean' after removal");
     }
+
 }

--- a/version.gradle
+++ b/version.gradle
@@ -6,6 +6,7 @@ ext {
             'log4j': '2.23.1',
             'junit': '5.10.3',
             'checkstyle': '10.20.0',
-            'jacoco': '0.8.12'
+            'jacoco': '0.8.12',
+            'mockito': '5.5.0'
     ]
 }


### PR DESCRIPTION
1. beanDefinitionMap: Used to store name and bean definition pairs.

2. registerBeanDefinition: Adds a new bean definition. If a bean with that name already exists, throws a BeanDefinitionStoreException.

3. Other methods: Implementation of the BeanDefinitionRegistry interface to support basic operations with the bean registry.